### PR TITLE
Added texture buffers for MacOS rendering compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,6 @@ after_build:
   - cd C:\Qt\latest\msvc2017_64\bin
   - windeployqt C:\projects\fish_deformation\unwind\unwind.exe
   - cd C:\projects\fish_deformation
-  - 7z a unwind.zip .\unwind\*
+  - 7z a unwind.zip unwind\
 artifacts:
   - path: unwind.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,13 +5,37 @@ clone_folder: C:\projects\fish_deformation
 branches:
   only:
     - master
+    - michael
 install:
   - git submodule update --init --recursive
   - cinstall: python
+build:
+  parallel: true
 build_script:
-  - echo Running cmake...
+  - echo Running cmake ..
+  - cd c:\tools\vcpkg
+  - .\vcpkg.exe --triplet x64-windows install mpir mpfr
   - cd c:\projects\fish_deformation
+  - set PATH=C:\Python%PYTHON%-x64;C:\Python%PYTHON%-x64\Scripts;%PATH%
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" -T "host=x64" ..
-  - msbuild %MSBuildOptions% fish_deformation
+  - cmake -G "Visual Studio 15 2017 Win64"
+      -DCMAKE_PREFIX_PATH="C:/Qt/5.10.1/msvc2017_64/lib/cmake"  
+      -DMPFR_INCLUDE_DIR:PATH="C:/tools/vcpkg/installed/x64-windows/include" 
+      -DMPFR_LIBRARIES:FILEPATH="C:/tools/vcpkg/installed/x64-windows/lib/mpfr.lib" 
+      -DGMP_INCLUDE_DIR:PATH="C:/tools/vcpkg/installed/x64-windows/include" 
+      -DGMP_LIBRARIES:FILEPATH="C:/tools/vcpkg/installed/x64-windows/lib/mpir.lib" 
+      -DBOOST_ROOT="C:/Libraries/boost_1_65_1" ../
+  - set MSBuildOptions=/v:m /p:Configuration=Release /p:Platform=x64
+  - msbuild %MSBuildOptions% fish_deformation.sln
+after_build:
+  - cd ..
+  - mkdir unwind
+  - copy build\src\Release\unwind.exe unwind
+  - copy build\src\Release\mpir.dll unwind
+  - cd C:\Qt\latest\msvc2017_64\bin
+  - windeployqt C:\projects\fish_deformation\unwind\unwind.exe
+  - cd C:\projects\fish_deformation
+  - 7z a unwind.zip .\unwind\*
+artifacts:
+  - path: unwind.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,21 @@ matrix:
     compiler: gcc-7
     env:
     - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7 CONFIG=Release PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7'"
+  - os: osx
+    osx_image: xcode10.2
+    compiler: clang
+    env:
+    - MATRIX_EVAL="export CONFIG=Release PYTHON=python3 LIBIGL_NUM_THREADS=1"
+  - os: osx
+    osx_image: xcode10.2
+    compiler: clang
+    env:
+    - MATRIX_EVAL="export CONFIG=Release PYTHON=python3 LIBIGL_NUM_THREADS=1 CMAKE_EXTRA='-DLIBIGL_USE_STATIC_LIBRARY=OFF'"
+  - os: osx
+    osx_image: xcode10.2
+    compiler: clang
+    env:
+    - MATRIX_EVAL="export CONFIG=Release PYTHON=python3 LIBIGL_NUM_THREADS=1 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7'""
 
 install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,71 @@
+dist: trusty
+sudo: true
+language: cpp
+cache: ccache
+branches:
+  only:
+    - master
+    - michael
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - cmake
+    - g++-6
+    - gcc-6
+    - g++-7
+    - gcc-7
+    - libblas-dev
+    - libboost-filesystem-dev
+    - libboost-system-dev
+    - libboost-thread-dev
+    - libglu1-mesa-dev
+    - liblapack-dev
+    - libmpfr-dev
+    - libpython3-dev
+    - python3-setuptools
+    - qt5-default
+    - xorg-dev
+  homebrew:
+    packages:
+    - ccache
+matrix:
+  include:
+  - os: linux
+    compiler: gcc-6
+    env:
+    - MATRIX_EVAL="export CC=gcc-6 CXX=g++-6 CONFIG=Release PYTHON=python3"
+  - os: linux
+    compiler: gcc-7
+    env:
+    - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7 CONFIG=Release PYTHON=python3"
+  - os: linux # same config like above but with -DLIBIGL_USE_STATIC_LIBRARY=OFF to test static and header-only builds
+    compiler: gcc-7
+    env:
+    - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7 CONFIG=Release PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_USE_STATIC_LIBRARY=OFF'"
+  - os: linux
+    compiler: gcc-7
+    env:
+    - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7 CONFIG=Release PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7'"
+
+install:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
+- eval "${MATRIX_EVAL}"
+- ccache --max-size=5.0G
+- ccache -V && ccache --show-stats && ccache --zero-stats
+
+script:
+# Tutorials and tests
+- mkdir build
+- pushd build
+- cmake ${CMAKE_EXTRA}
+    -DCMAKE_BUILD_TYPE=$CONFIG
+    -DLIBIGL_CHECK_UNDEFINED=ON
+    -DLIBIGL_WITH_CGAL=ON
+    ../
+- make -j8
+- ctest --verbose
+- popd
+- rm -rf build
+- ccache --show-stats

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,9 @@ project(fish_deformation)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/src/utils/voroffset/cmake)
-<<<<<<< HEAD
-
-
-=======
 if (APPLE)
   set(CMAKE_PREFIX_PATH /usr/local/opt/qt/lib/cmake)
 endif ()
->>>>>>> 246fe30... Modified OpenMP and Qt5 compilation settings
 
 
 #################################
@@ -116,17 +111,12 @@ file(GLOB CT_SRCS external/Segmentangling/ContourTree/*.cpp)
 set(CT_INCLUDE_DIRS external/Segmentangling/ContourTree)
 list(REMOVE_ITEM CT_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/external/Segmentangling/ContourTree/main.cpp")
 add_library(contourtree STATIC ${CT_SRCS})
-<<<<<<< HEAD
-target_compile_options(contourtree PRIVATE "-fopenmp")
-target_link_libraries(contourtree Qt5::Core Qt5::Widgets -fopenmp spdlog)
-=======
 if (NOT APPLE)
   target_compile_options(contourtree PRIVATE "-fopenmp")
   target_link_libraries(contourtree Qt5::Core Qt5::Widgets -fopenmp spdlog)
 else ()
   target_link_libraries(contourtree Qt5::Core Qt5::Widgets spdlog)
 endif ()
->>>>>>> 246fe30... Modified OpenMP and Qt5 compilation settings
 target_include_directories(contourtree PUBLIC ${CT_INCLUDE_DIRS})
 target_compile_definitions(contourtree PUBLIC CONTOUR_TREE_USE_SPDLOG)
 
@@ -140,7 +130,7 @@ list(FILTER UTILS_HEADER EXCLUDE REGEX cgal*)
 add_library(utils STATIC ${UTILS_SRCS} ${UTILS_HEADER})
 set_property(TARGET utils PROPERTY CXX_STANDARD 14)
 set_property(TARGET utils PROPERTY CXX_STANDARD_REQUIRED ON)
-target_link_libraries(utils igl::core igl::opengl igl::cgal igl::triangle spdlog Qt5::Core Qt5::Widgets spdlog)
+target_link_libraries(utils igl::core igl::opengl igl::cgal igl::triangle spdlog Qt5::Core Qt5::Widgets spdlog glfw ${GLFW_LIBRARIES})
 target_include_directories(utils PUBLIC ${UTILS_INCLUDE_DIRS})
 target_include_directories(utils SYSTEM PUBLIC "${PROJECT_SOURCE_DIR}/external/glm")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ list(FILTER UTILS_HEADER EXCLUDE REGEX cgal*)
 add_library(utils STATIC ${UTILS_SRCS} ${UTILS_HEADER})
 set_property(TARGET utils PROPERTY CXX_STANDARD 14)
 set_property(TARGET utils PROPERTY CXX_STANDARD_REQUIRED ON)
-target_link_libraries(utils igl::core igl::opengl igl::cgal igl::triangle spdlog Qt5::Core Qt5::Widgets spdlog glfw ${GLFW_LIBRARIES})
+target_link_libraries(utils igl::core igl::opengl igl::cgal igl::triangle spdlog Qt5::Core Qt5::Widgets spdlog glfw)
 target_include_directories(utils PUBLIC ${UTILS_INCLUDE_DIRS})
 target_include_directories(utils SYSTEM PUBLIC "${PROJECT_SOURCE_DIR}/external/glm")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,14 @@ project(fish_deformation)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/src/utils/voroffset/cmake)
+<<<<<<< HEAD
 
 
+=======
+if (APPLE)
+  set(CMAKE_PREFIX_PATH /usr/local/opt/qt/lib/cmake)
+endif ()
+>>>>>>> 246fe30... Modified OpenMP and Qt5 compilation settings
 
 
 #################################
@@ -110,8 +116,17 @@ file(GLOB CT_SRCS external/Segmentangling/ContourTree/*.cpp)
 set(CT_INCLUDE_DIRS external/Segmentangling/ContourTree)
 list(REMOVE_ITEM CT_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/external/Segmentangling/ContourTree/main.cpp")
 add_library(contourtree STATIC ${CT_SRCS})
+<<<<<<< HEAD
 target_compile_options(contourtree PRIVATE "-fopenmp")
 target_link_libraries(contourtree Qt5::Core Qt5::Widgets -fopenmp spdlog)
+=======
+if (NOT APPLE)
+  target_compile_options(contourtree PRIVATE "-fopenmp")
+  target_link_libraries(contourtree Qt5::Core Qt5::Widgets -fopenmp spdlog)
+else ()
+  target_link_libraries(contourtree Qt5::Core Qt5::Widgets spdlog)
+endif ()
+>>>>>>> 246fe30... Modified OpenMP and Qt5 compilation settings
 target_include_directories(contourtree PUBLIC ${CT_INCLUDE_DIRS})
 target_compile_definitions(contourtree PUBLIC CONTOUR_TREE_USE_SPDLOG)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "ui/endpoint_selection_plugin.h"
 #include "ui/bounding_polygon_plugin.h"
 #include "ui/state.h"
+#include "utils/utils.h"
 #include "Logger.hpp"
 
 State _state;
@@ -26,9 +27,11 @@ void log_opengl_debug(GLenum source, GLenum type, GLuint id, GLenum severity,
     if (id == 131185 || id == 7 || id == 131218) {
         return;
     }
+#if !defined(__APPLE__)
     if (source == GL_DEBUG_SOURCE_APPLICATION) {
         return;
     }
+#endif
     _state.logger->error(
         "OpenGL Debug msg: Source: {}, Type: {}, Id: {}, Severity: {}, Message: {}",
         source, type, id, severity, std::string(message)
@@ -56,9 +59,7 @@ bool init(igl::opengl::glfw::Viewer& viewer) {
     ct_logger->set_level(CONTOURTREE_LOGGER_LEVEL);
     contourtree::Logger::setLogger(ct_logger);
 
-#if !defined(__APPLE__)
-    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-    glDebugMessageCallback(log_opengl_debug, NULL);
+    init_opengl_debug(log_opengl_debug);
 
     return false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ bool init(igl::opengl::glfw::Viewer& viewer) {
     ct_logger->set_level(CONTOURTREE_LOGGER_LEVEL);
     contourtree::Logger::setLogger(ct_logger);
 
+#if !defined(__APPLE__)
     glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
     glDebugMessageCallback(log_opengl_debug, NULL);
 

--- a/src/ui/bounding_polygon_plugin.cpp
+++ b/src/ui/bounding_polygon_plugin.cpp
@@ -399,9 +399,6 @@ bool Bounding_Polygon_Menu::post_draw() {
 
     ImGui::SameLine();
     ImVec2 cursor_pos = ImGui::GetCursorScreenPos();
-#ifdef __APPLE__
-    cursor_pos.x *= (1.0+keyframe_nudge_amount);
-#endif
     ImGui::PushItemWidth(ImGui::GetWindowWidth() - 2.f*cursor_pos.x);
     if(ImGui::SliderFloat("", &current_cut_index,
                           static_cast<float>(state.cage.min_index()),

--- a/src/ui/bounding_polygon_plugin.cpp
+++ b/src/ui/bounding_polygon_plugin.cpp
@@ -401,6 +401,9 @@ bool Bounding_Polygon_Menu::post_draw() {
 
     ImGui::SameLine();
     ImVec2 cursor_pos = ImGui::GetCursorScreenPos();
+#ifdef __APPLE__
+    cursor_pos.x *= (1.0+keyframe_nudge_amount);
+#endif
     ImGui::PushItemWidth(ImGui::GetWindowWidth() - 2.f*cursor_pos.x);
     if(ImGui::SliderFloat("", &current_cut_index,
                           static_cast<float>(state.cage.min_index()),

--- a/src/ui/bounding_polygon_plugin.cpp
+++ b/src/ui/bounding_polygon_plugin.cpp
@@ -59,9 +59,7 @@ void Bounding_Polygon_Menu::deinitialize() {
 }
 
 bool Bounding_Polygon_Menu::is_2d_widget_in_focus()  {
-    double mouse_x, mouse_y;
-    glfwGetCursorPos(viewer->window, &mouse_x, &mouse_y);
-    glm::vec2 p(mouse_x, mouse_y);
+    glm::vec2 p(viewer->current_mouse_x, viewer->current_mouse_y);
     return widget_2d.is_point_in_widget(p) && !mouse_in_popup;
 }
 
@@ -502,10 +500,8 @@ bool Bounding_Polygon_Menu::post_draw() {
         ImVec2 popup_size = ImGui::GetWindowSize();
         tf_widget.post_draw(!show_save_popup /* active */);
 
-        double mouse_x, mouse_y;
-        glfwGetCursorPos(viewer->window, &mouse_x, &mouse_y);
-        bool in_window_x = (mouse_x >= popup_pos[0]) && (mouse_x <= (popup_pos[0] + popup_size[0]));
-        bool in_window_y = (mouse_y >= popup_pos[1]) && (mouse_y <= (popup_pos[1] + popup_size[1]));
+        bool in_window_x = (viewer->current_mouse_x >= popup_pos[0]) && (viewer->current_mouse_x <= (popup_pos[0] + popup_size[0]));
+        bool in_window_y = (viewer->current_mouse_y >= popup_pos[1]) && (viewer->current_mouse_y <= (popup_pos[1] + popup_size[1]));
         mouse_in_popup = (in_window_x && in_window_y);
 
         ImGui::Separator();

--- a/src/ui/bounding_widget_2d.cpp
+++ b/src/ui/bounding_widget_2d.cpp
@@ -565,7 +565,7 @@ bool Bounding_Polygon_Widget::post_draw(BoundingCage::KeyFrameIterator kf, bool 
     //
     // Render the slice of the volume for this keyframe into an OpenGL texture
     //
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Render slice");
+    push_gl_debug_group("Render slice");
     {
         glUseProgram(plane.program);
         glBindVertexArray(empty_vao);
@@ -602,13 +602,13 @@ bool Bounding_Polygon_Widget::post_draw(BoundingCage::KeyFrameIterator kf, bool 
         glBindVertexArray(0);
         glUseProgram(0);
     }
-    glPopDebugGroup();
+    pop_gl_debug_group();
 
 
     //
     // Render the bounding-box, center, and axes into the same texture
     //
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Render polygon");
+    push_gl_debug_group("Render polygon");
     {
         const glm::vec2 centroid_2d = G2f(kf->centroid_2d());
         const glm::vec2 r_axis = G2f(kf->right_rotated_2d()), u_axis = G2f(kf->up_rotated_2d());
@@ -649,7 +649,7 @@ bool Bounding_Polygon_Widget::post_draw(BoundingCage::KeyFrameIterator kf, bool 
             }
         }
     }
-    glPopDebugGroup();
+    pop_gl_debug_group();
 
     // Restore the framebuffer and viewport
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -660,7 +660,7 @@ bool Bounding_Polygon_Widget::post_draw(BoundingCage::KeyFrameIterator kf, bool 
     //
     // Blit the texture we just rendered to the screen
     //
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Texture Blit");
+    push_gl_debug_group("Texture Blit");
     {
         int width;
         int height;
@@ -711,7 +711,7 @@ bool Bounding_Polygon_Widget::post_draw(BoundingCage::KeyFrameIterator kf, bool 
         glBindVertexArray(0);
         glUseProgram(0);
     }
-    glPopDebugGroup();
+    pop_gl_debug_group();
     glEnable(GL_DEPTH_TEST);
 
     return false;

--- a/src/ui/bounding_widget_2d.cpp
+++ b/src/ui/bounding_widget_2d.cpp
@@ -2,6 +2,8 @@
 
 #include "bounding_polygon_plugin.h"
 
+#include "utils/utils.h"
+
 #include <igl/opengl/create_shader_program.h>
 #include <igl/opengl/glfw/Viewer.h>
 #include <imgui/imgui.h>

--- a/src/ui/state.cpp
+++ b/src/ui/state.cpp
@@ -65,7 +65,6 @@ void State::load_volume_data(State::LoadedVolume& volume, std::string prefix, bo
     }
 }
 
-
 void State::LoadedVolume::load_gl_volume_texture(const std::vector<uint8_t>& byte_data) {
     if (byte_data.size() == 0) {
         return;

--- a/src/utils/bounding_cage.h
+++ b/src/utils/bounding_cage.h
@@ -457,6 +457,7 @@ public:
 
         bool bump(double amount) {
             this->_origin += amount * this->normal();
+            return true;
         }
 
         /// Rotate the coordinate frame counter-clockwise about the normal axis

--- a/src/utils/gl/point_line_rendering.cpp
+++ b/src/utils/gl/point_line_rendering.cpp
@@ -1,5 +1,7 @@
 #include "point_line_rendering.h"
 
+#include "utils/utils.h"
+
 #include <igl/opengl/create_shader_program.h>
 
 #include <glm/gtc/type_ptr.hpp>

--- a/src/utils/gl/point_line_rendering.cpp
+++ b/src/utils/gl/point_line_rendering.cpp
@@ -70,7 +70,7 @@ void PointLineRenderer::destroy() {
 
 
 bool PointLineRenderer::update_polyline_3d(int polyline_id, GLfloat* vertices, GLfloat* colors, GLsizei num_vertices, PolylineStyle style) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "update_polyline_3d");
+    push_gl_debug_group("update_polyline_3d");
     if (polyline_id >= _polylines.size() || polyline_id < 0) {
         return false;
     }
@@ -95,12 +95,12 @@ bool PointLineRenderer::update_polyline_3d(int polyline_id, GLfloat* vertices, G
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    glPopDebugGroup();
+    pop_gl_debug_group();
     return true;
 }
 
 bool PointLineRenderer::update_polyline_3d(int polyline_id, GLfloat* vertices, glm::vec4 color, GLsizei num_vertices, PolylineStyle style) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "update_polyline_3d");
+    push_gl_debug_group("update_polyline_3d");
     if (polyline_id >= _polylines.size() || polyline_id < 0) {
         return false;
     }
@@ -125,13 +125,13 @@ bool PointLineRenderer::update_polyline_3d(int polyline_id, GLfloat* vertices, g
     glDisableVertexAttribArray(1);
     glBindVertexArray(0);
 
-    glPopDebugGroup();
+    pop_gl_debug_group();
     return true;
 }
 
 
 int PointLineRenderer::add_polyline_3d(GLfloat* vertices, GLfloat* colors, GLsizei num_vertices, PolylineStyle style) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "add_polyline_3d");
+    push_gl_debug_group("add_polyline_3d");
 
     Polyline polyline;
 
@@ -172,13 +172,13 @@ int PointLineRenderer::add_polyline_3d(GLfloat* vertices, GLfloat* colors, GLsiz
         _polylines.push_back(polyline);
     }
 
-    glPopDebugGroup();
+    pop_gl_debug_group();
 
     return polyline_id;
 }
 
 int PointLineRenderer::add_polyline_3d(GLfloat* vertices, glm::vec4 color, GLsizei num_vertices, PolylineStyle style) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "add_polyline_3d");
+    push_gl_debug_group("add_polyline_3d");
 
     Polyline polyline;
 
@@ -212,7 +212,7 @@ int PointLineRenderer::add_polyline_3d(GLfloat* vertices, glm::vec4 color, GLsiz
         _polylines.push_back(polyline);
     }
 
-    glPopDebugGroup();
+    pop_gl_debug_group();
 
     return polyline_id;
 }

--- a/src/utils/gl/selection_renderer.h
+++ b/src/utils/gl/selection_renderer.h
@@ -54,10 +54,16 @@ class SelectionRenderer {
             GLuint program_object = 0;
             GLuint transfer_function_texture;
 
-            GLuint selection_list_ssbo;
-            GLuint contour_information_ssbo;
+            GLuint selection_texture;
+            GLuint contour_texture;
+
+            GLuint selection_list_tbo;
+            GLuint contour_information_tbo;
 
             struct {
+                GLint selection_texture = 0;
+                GLint contour_texture = 0;
+                
                 GLint entry_texture = 0;
                 GLint exit_texture = 0;
                 GLint volume_texture = 0;
@@ -87,6 +93,7 @@ class SelectionRenderer {
             GLuint picking_texture = 0;
 
             struct {
+                GLint contour_texture = 0;
                 GLint entry_texture = 0;
                 GLint exit_texture = 0;
                 GLint volume_texture = 0;

--- a/src/utils/gl/volume_exporter.cpp
+++ b/src/utils/gl/volume_exporter.cpp
@@ -9,6 +9,8 @@
 #include <igl/opengl/create_shader_program.h>
 #include <utils/nrrd/NRRD/nrrd.hxx>
 
+#include "utils/utils.h"
+
 constexpr const char* SLICE_VERTEX_SHADER = R"(
 #version 150
 // Create two triangles that are filling the entire screen [-1, 1]

--- a/src/utils/gl/volume_exporter.cpp
+++ b/src/utils/gl/volume_exporter.cpp
@@ -70,7 +70,7 @@ void main() {
 )";
 
 void VolumeExporter::write_texture_data_to_file(std::string filename) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Export");
+    push_gl_debug_group("Export");
     const size_t num_voxels = size_t(w)*size_t(h)*size_t(d);
     std::vector<std::uint8_t> out_data;
     out_data.resize(num_voxels*4);
@@ -84,7 +84,7 @@ void VolumeExporter::write_texture_data_to_file(std::string filename) {
     real_data.resize(num_voxels);
     for (size_t i = 0; i < num_voxels; i++) { real_data[i] = out_data[4*i]; }
     NRRD::save3D <uint8_t> (filename, real_data.data(), this->w, this->h, this->d);
-    glPopDebugGroup();
+    pop_gl_debug_group();
 }
 
 void VolumeExporter::set_export_dims(GLsizei w, GLsizei h, GLsizei d) {
@@ -105,7 +105,7 @@ void VolumeExporter::destroy() {
 }
 
 void VolumeExporter::init(GLsizei w, GLsizei h, GLsizei d) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Init Slice");
+    push_gl_debug_group("Init Slice");
     igl::opengl::create_shader_program(SLICE_VERTEX_SHADER,
                                        SLICE_FRAGMENT_SHADER, {}, slice.program);
     slice.ll_location = glGetUniformLocation(slice.program, "ll");
@@ -132,7 +132,7 @@ void VolumeExporter::init(GLsizei w, GLsizei h, GLsizei d) {
     glGenFramebuffers(1, &framebuffer);
 
     glBindTexture(GL_TEXTURE_3D, 0);
-    glPopDebugGroup();
+    pop_gl_debug_group();
 
 }
 
@@ -142,7 +142,7 @@ void VolumeExporter::update(BoundingCage& cage, GLuint volume_texture, glm::ivec
     GLint old_viewport[4];
     glGetIntegerv(GL_VIEWPORT, old_viewport);
 
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Export Slice");
+    push_gl_debug_group("Export Slice");
     glUseProgram(slice.program);
     glBindVertexArray(empty_vao);
 
@@ -205,7 +205,7 @@ void VolumeExporter::update(BoundingCage& cage, GLuint volume_texture, glm::ivec
     glBindVertexArray(0);
     glUseProgram(0);
     glBindTexture(GL_TEXTURE_3D, 0);
-    glPopDebugGroup();
+    pop_gl_debug_group();
 
     glViewport(old_viewport[0], old_viewport[1], old_viewport[2], old_viewport[3]);
 }

--- a/src/utils/gl/volume_renderer.cpp
+++ b/src/utils/gl/volume_renderer.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <array>
 
+#include "utils/utils.h"
 
 namespace {
 

--- a/src/utils/gl/volume_renderer.cpp
+++ b/src/utils/gl/volume_renderer.cpp
@@ -502,7 +502,7 @@ void VolumeRenderer::init(const glm::ivec2 &viewport_size, const char *fragment_
 
 
     // Generate multipass buffers if enabled
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Init VolumeRenderer Multipass");
+    push_gl_debug_group("Init VolumeRenderer Multipass");
     for (int i = 0; i < 2; i++) {
         glGenTextures(1, &_gl_state.multipass.texture[i]);
         glBindTexture(GL_TEXTURE_2D, _gl_state.multipass.texture[i]);
@@ -518,11 +518,11 @@ void VolumeRenderer::init(const glm::ivec2 &viewport_size, const char *fragment_
     }
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glBindTexture(GL_TEXTURE_2D, 0);
-    glPopDebugGroup();
+    pop_gl_debug_group();
 }
 
 void VolumeRenderer::ray_endpoint_pass(const glm::mat4& model_matrix, const glm::mat4& view_matrix, const glm::mat4& proj_matrix) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Render Bounding Box");
+    push_gl_debug_group("Render Bounding Box");
     {
         const glm::vec4 color_transparent(0.0);
 
@@ -579,11 +579,11 @@ void VolumeRenderer::ray_endpoint_pass(const glm::mat4& model_matrix, const glm:
             glDisable(GL_CULL_FACE);
         }
     }
-    glPopDebugGroup();
+    pop_gl_debug_group();
 }
 
 void VolumeRenderer::volume_pass(const glm::vec3& light_position, const glm::ivec3& volume_dims, GLuint volume_tex, GLuint multipass_tex) {
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Render Volume TEST");
+    push_gl_debug_group("Render Volume TEST");
 
     //
     //  Setup
@@ -641,7 +641,7 @@ void VolumeRenderer::volume_pass(const glm::vec3& light_position, const glm::ive
 
     glBindVertexArray(0);
 
-    glPopDebugGroup();
+    pop_gl_debug_group();
 }
 
 void VolumeRenderer::begin(const glm::ivec3& volume_dims, GLuint tex) {
@@ -683,7 +683,7 @@ void VolumeRenderer::render_pass(
     const int current_buf = _current_multipass_buf;
     const int last_buf = (_current_multipass_buf+1) % 2;
 
-    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Multipass render");
+    push_gl_debug_group("Multipass render");
 
     GLint old_viewport[4];
     glGetIntegerv(GL_VIEWPORT, old_viewport);
@@ -710,7 +710,7 @@ void VolumeRenderer::render_pass(
     volume_pass(light_position, _current_volume_dims, volume_tex, _gl_state.multipass.texture[last_buf]);
 
     glViewport(old_viewport[0], old_viewport[1], old_viewport[2], old_viewport[3]);
-    glPopDebugGroup();
+    pop_gl_debug_group();
 }
 
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -189,20 +189,25 @@ bool load_rawfile(const std::string& rawfilename, const Eigen::RowVector3i& dims
     return true;
 }
 
-<<<<<<< HEAD
-=======
-void debug_group_action(const std::string& action, const char* message) {
+void init_opengl_debug(GLDEBUGPROC callback) {
 #if !defined(__APPLE__)
-    if (action == "PUSH") {
-        glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, message);
-    }
-    else if (action == "POP") {
-        glPopDebugGroup();
-    }
+    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+    glDebugMessageCallback(callback, NULL);
 #endif
 }
 
->>>>>>> 35e12f7... Added dependencies for debug group functions
+void push_gl_debug_group(const char* message) {
+#if !defined(__APPLE__)
+    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, message);
+#endif
+}
+
+void pop_gl_debug_group() {
+#if !defined(__APPLE__)
+    glPopDebugGroup();
+#endif
+}
+
 void edge_endpoints(const Eigen::MatrixXd& V,
                     const Eigen::MatrixXi& F,
                     Eigen::MatrixXd& V1,

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -189,6 +189,20 @@ bool load_rawfile(const std::string& rawfilename, const Eigen::RowVector3i& dims
     return true;
 }
 
+<<<<<<< HEAD
+=======
+void debug_group_action(const std::string& action, const char* message) {
+#if !defined(__APPLE__)
+    if (action == "PUSH") {
+        glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, message);
+    }
+    else if (action == "POP") {
+        glPopDebugGroup();
+    }
+#endif
+}
+
+>>>>>>> 35e12f7... Added dependencies for debug group functions
 void edge_endpoints(const Eigen::MatrixXd& V,
                     const Eigen::MatrixXi& F,
                     Eigen::MatrixXd& V1,

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -6,6 +6,8 @@
 #include <vector>
 #include <array>
 #include <memory>
+#include <glad/glad.h>
+#include <glm/glm.hpp>
 
 
 #ifdef _MSC_VER
@@ -42,6 +44,11 @@ bool load_rawfile(const std::string& rawfilename, const Eigen::RowVector3i& dims
 
 bool load_rawfile(const std::string& rawfilename, const Eigen::RowVector3i& dims, std::vector<uint8_t> &out, std::shared_ptr<spdlog::logger> logger);
 
+<<<<<<< HEAD
+=======
+void debug_group_action(const std::string& action, const char* message="");
+
+>>>>>>> 35e12f7... Added dependencies for debug group functions
 void edge_endpoints(const Eigen::MatrixXd& V,
                     const Eigen::MatrixXi& F,
                     Eigen::MatrixXd& V1,

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -7,7 +7,7 @@
 #include <array>
 #include <memory>
 #include <glad/glad.h>
-#include <glm/glm.hpp>
+#include <GLFW/glfw3.h>
 
 
 #ifdef _MSC_VER
@@ -44,11 +44,12 @@ bool load_rawfile(const std::string& rawfilename, const Eigen::RowVector3i& dims
 
 bool load_rawfile(const std::string& rawfilename, const Eigen::RowVector3i& dims, std::vector<uint8_t> &out, std::shared_ptr<spdlog::logger> logger);
 
-<<<<<<< HEAD
-=======
-void debug_group_action(const std::string& action, const char* message="");
+void init_opengl_debug(GLDEBUGPROC callback);
 
->>>>>>> 35e12f7... Added dependencies for debug group functions
+void push_gl_debug_group(const char* message);
+
+void pop_gl_debug_group();
+
 void edge_endpoints(const Eigen::MatrixXd& V,
                     const Eigen::MatrixXi& F,
                     Eigen::MatrixXd& V1,


### PR DESCRIPTION
Replaced old buffers with new texture buffers and texture buffer objects to ensure compatibility of 3D volumetric and 2D slice rendering in application windows for volume and endpoint selection as well as in the bounding polygon window responsible for generating the 3D and 2D widget viewers. 

Also implemented new debug helper functions to integrate debugging functions together into one common interface for ease of use on the part of Windows and Linux users for troubleshooting. Modified mouse coordinates to fetch data from mouse position inputs instead of cursor inputs and successfully integrated CI for all platforms (Linux, Windows, MacOS) into source code.